### PR TITLE
fix: 修复从env文件加载websocket配置失败的问题

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,13 +9,14 @@ import {
   FastifyAdapter,
   NestFastifyApplication,
 } from '@nestjs/platform-fastify';
-import { IoAdapter } from '@nestjs/platform-socket.io';
 import { ValidationError } from 'class-validator';
 import { AppModule } from './app.module';
 import { ApiExceptionFilter } from './common/filters/api-exception.filter';
 import { ApiTransformInterceptor } from './common/interceptors/api-transform.interceptor';
 import { setupSwagger } from './setup-swagger';
 import { LoggerService } from './shared/logger/logger.service';
+import { SocketIoAdapter } from '@/modules/ws/socket-io.adapter';
+import { ConfigService } from '@nestjs/config';
 
 const PORT = process.env.PORT;
 
@@ -54,7 +55,7 @@ async function bootstrap() {
   // api interceptor
   app.useGlobalInterceptors(new ApiTransformInterceptor(new Reflector()));
   // websocket
-  app.useWebSocketAdapter(new IoAdapter());
+  app.useWebSocketAdapter(new SocketIoAdapter(app, app.get(ConfigService)));
   // swagger
   setupSwagger(app);
   // start

--- a/src/modules/ws/admin-ws.gateway.ts
+++ b/src/modules/ws/admin-ws.gateway.ts
@@ -12,10 +12,7 @@ import { EVENT_OFFLINE, EVENT_ONLINE } from './ws.event';
 /**
  * Admin WebSokcet网关，不含权限校验，Socket端只做通知相关操作
  */
-@WebSocketGateway(parseInt(process.env.WS_PORT), {
-  path: process.env.WS_PATH,
-  namespace: '/admin',
-})
+@WebSocketGateway()
 export class AdminWSGateway
   implements OnGatewayConnection, OnGatewayDisconnect, OnGatewayInit
 {

--- a/src/modules/ws/socket-io.adapter.ts
+++ b/src/modules/ws/socket-io.adapter.ts
@@ -1,0 +1,27 @@
+import { IoAdapter } from '@nestjs/platform-socket.io';
+import { INestApplicationContext } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+// https://stackoverflow.com/questions/69435506/how-to-pass-a-dynamic-port-to-the-websockets-gateway-in-nestjs
+export class SocketIoAdapter extends IoAdapter {
+  constructor(
+    private app: INestApplicationContext,
+    private configService: ConfigService,
+  ) {
+    super(app);
+  }
+
+  create(port: number, options?: any) {
+    port = this.configService.get<number>('WS_PORT');
+    options.path = this.configService.get<string>('WS_PATH');
+    options.namespace = '/admin';
+    return super.create(port, options);
+  }
+
+  createIOServer(port: number, options?: any) {
+    port = this.configService.get<number>('WS_PORT');
+    options.path = this.configService.get<string>('WS_PATH');
+    options.namespace = '/admin';
+    return super.createIOServer(port, options);
+  }
+}


### PR DESCRIPTION
使用yarn dev进行开发是，admin-ws.gateway.ts文件中WebSocketGateway装饰器拿不到WS_PORT和WS_PATH导致启动的websocket server不符合预期。