### PR TITLE
fix: Swagger cannot upload files, the first use of upload module error: ENOENT: no such file or directory

### DIFF
--- a/src/modules/tools/upload/upload.dto.ts
+++ b/src/modules/tools/upload/upload.dto.ts
@@ -6,7 +6,7 @@ import { IsDefined } from 'class-validator'
 import { IsFile } from './file.constraint'
 
 export class FileUploadDto {
-  @ApiProperty({ type: Buffer, format: 'binary', description: '文件' })
+  @ApiProperty({ type: 'string', format: 'binary', description: '文件' })
   @IsDefined()
   @IsFile(
     {

--- a/src/modules/tools/upload/upload.service.ts
+++ b/src/modules/tools/upload/upload.service.ts
@@ -1,6 +1,7 @@
 import { MultipartFile } from '@fastify/multipart'
 import { Injectable, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
+import dayjs from 'dayjs'
 import { isNil } from 'lodash'
 import { Repository } from 'typeorm'
 
@@ -34,9 +35,10 @@ export class UploadService {
     const extName = getExtname(fileName)
     const type = getFileType(extName)
     const name = fileRename(fileName)
-    const path = getFilePath(name)
+    const currentDate = dayjs().format('YYYY-MM-DD')
+    const path = getFilePath(name, currentDate, type)
 
-    saveLocalFile(await file.toBuffer(), name)
+    saveLocalFile(await file.toBuffer(), name, currentDate, type)
 
     await this.storageRepository.save({
       name,

--- a/src/utils/file.util.ts
+++ b/src/utils/file.util.ts
@@ -65,13 +65,21 @@ export function fileRename(fileName: string) {
   return `${name}-${time}${extName}`
 }
 
-export function getFilePath(name: string) {
-  return `/upload/${name}`
+export function getFilePath(name: string, currentDate: string, type: string) {
+  return `/upload/${currentDate}/${type}/${name}`
 }
 
-export function saveLocalFile(buffer: Buffer, name: string) {
-  const filePath = path.join(__dirname, '../../', 'public/upload', name)
-  const writeStream = fs.createWriteStream(filePath)
+export async function saveLocalFile(buffer: Buffer, name: string, currentDate: string, type: string) {
+  const filePath = path.join(__dirname, '../../', 'public/upload/', `${currentDate}/`, `${type}/`)
+  try {
+    // 判断是否有该文件夹
+    await fs.promises.stat(filePath)
+  }
+  catch (error) {
+    // 没有该文件夹就创建
+    await fs.promises.mkdir(filePath, { recursive: true })
+  }
+  const writeStream = fs.createWriteStream(filePath + name)
   writeStream.write(buffer)
 }
 


### PR DESCRIPTION
修复：

1. Swagger 无法选择文件进行上传
2. 首次使用上传模块报错：ENOENT: no such file or directory