### PR TITLE
sys user 更新时若不带roleids会导致报错

### DIFF
--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -202,13 +202,13 @@ export class UserService {
         .leftJoinAndSelect('user.dept', 'dept')
         .where('user.id = :id', { id })
         .getOne()
-
+      if(roleIds)
       await manager
         .createQueryBuilder()
         .relation(UserEntity, 'roles')
         .of(id)
         .addAndRemove(roleIds, user.roles)
-
+      if(deptId)
       await manager
         .createQueryBuilder()
         .relation(UserEntity, 'dept')


### PR DESCRIPTION
使用put /api/system/users/:id 时修改password时会报错没携带role_id

最小复现：
```
curl --location --request PUT 'http://localhost:7001/api/system/users/1' \
--header 'User-Agent: Apifox/1.0.0 (https://apifox.com)' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer 这里加管理员token' \
--header 'Accept: */*' \
--header 'Host: localhost:7001' \
--header 'Connection: keep-alive' \
--data-raw '{
    "password":"a1234567"
}'
```
报错提示：
```
{
    "code": 500,
    "message": "Field 'role_id' doesn't have a default value",
    "data": null
}