### PR TITLE
fix: 修复token过期后，获取图片验证码接口依然报1101问题

### DIFF
--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -4,11 +4,12 @@ import { env, envBoolean, envNumber } from '~/global/env'
 
 export const appRegToken = 'app'
 
+const globalPrefix = env('GLOBAL_PREFIX', 'api')
 export const AppConfig = registerAs(appRegToken, () => ({
   name: env('APP_NAME'),
   port: envNumber('APP_PORT', 3000),
   baseUrl: env('APP_BASE_URL'),
-  globalPrefix: env('GLOBAL_PREFIX', 'api'),
+  globalPrefix,
   locale: env('APP_LOCALE', 'zh-CN'),
   /** 是否允许多端登录 */
   multiDeviceLogin: envBoolean('MULTI_DEVICE_LOGIN', true),
@@ -20,3 +21,8 @@ export const AppConfig = registerAs(appRegToken, () => ({
 }))
 
 export type IAppConfig = ConfigType<typeof AppConfig>
+
+export const RouterWhiteList: string[] = [
+  `${globalPrefix ? '/' : ''}${globalPrefix}/auth/captcha/img`,
+  `${globalPrefix ? '/' : ''}${globalPrefix}/auth/login`
+]

--- a/src/modules/auth/guards/jwt-auth.guard.ts
+++ b/src/modules/auth/guards/jwt-auth.guard.ts
@@ -23,6 +23,7 @@ import { checkIsDemoMode } from '~/utils'
 
 import { AuthStrategy, PUBLIC_KEY } from '../auth.constant'
 import { TokenService } from '../services/token.service'
+import { RouterWhiteList } from '~/config'
 
 /** @type {import('fastify').RequestGenericInterface} */
 interface RequestType {
@@ -56,7 +57,7 @@ export class JwtAuthGuard extends AuthGuard(AuthStrategy.JWT) {
     ])
     const request = context.switchToHttp().getRequest<FastifyRequest<RequestType>>()
     // const response = context.switchToHttp().getResponse<FastifyReply>()
-
+    if (RouterWhiteList.includes(request.routeOptions.url)) return true
     // TODO 此处代码的作用是判断如果在演示环境下，则拒绝用户的增删改操作，去掉此代码不影响正常的业务逻辑
     if (request.method !== 'GET' && !request.url.includes('/auth/login'))
       checkIsDemoMode()


### PR DESCRIPTION
token失效后，获取图片验证码接口也报token失效，图片验证码以及登录接口应为白名单，不受token影响