### PR TITLE
fix: 修复根据用户名查询文件时，没有找到用户id时报错问题

### DIFF
--- a/src/modules/tools/storage/storage.service.ts
+++ b/src/modules/tools/storage/storage.service.ts
@@ -60,7 +60,7 @@ export class StorageService {
         ...(size && { size: Between(size[0], size[1]) }),
         ...(time && { createdAt: Between(time[0], time[1]) }),
         ...(username && {
-          userId: await (await this.userRepository.findOneBy({ username })).id,
+          userId: await (await this.userRepository.findOneBy({ username }))?.id,
         }),
       })
       .orderBy('storage.created_at', 'DESC')


### PR DESCRIPTION
由于await (await this.userRepository.findOneBy({ username })) 没有找到用户，所以.id导致报错

![cd917355346eb56a41d09290540b048](https://github.com/user-attachments/assets/9d2010ac-6130-421c-98d7-09a85f6e89ec)
